### PR TITLE
getCombineConfig add processContext

### DIFF
--- a/lib/processor/module-compiler.js
+++ b/lib/processor/module-compiler.js
@@ -84,12 +84,12 @@ ModuleCompiler.prototype.beforeAll = function (processContext) {
 
     var moduleCombineConfigs = config.combine || {};
     if (typeof this.getCombineConfig === 'function') {
-        moduleCombineConfigs = this.getCombineConfig(moduleCombineConfigs) || moduleCombineConfigs;
+        moduleCombineConfigs = this.getCombineConfig(moduleCombineConfigs, processContext) || moduleCombineConfigs;
     }
 
     var moduleMapConfigs = config.map || {};
     if (typeof this.getMapConfig === 'function') {
-        moduleMapConfigs = this.getMapConfig(moduleMapConfigs) || moduleMapConfigs;
+        moduleMapConfigs = this.getMapConfig(moduleMapConfigs, processContext) || moduleMapConfigs;
     }
 
     var reader = new Reader(processContext, configFile);


### PR DESCRIPTION
在 getCombineConfig 中，使用 processContext 可以更灵活的进行一些文件分析和处理
